### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ Enter the Data you want to search.
  
 Url with the Search Result is opened.
 
+[![Run on Repl.it](https://repl.it/badge/github/NotSharwan/Python-Google-Search)](https://repl.it/github/NotSharwan/Python-Google-Search)
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@SharwanSolanki/Python-Google-Search).